### PR TITLE
Patch TCC location in desktop files

### DIFF
--- a/nix/tuxedo-control-center/default.nix
+++ b/nix/tuxedo-control-center/default.nix
@@ -75,6 +75,11 @@ stdenv.mkDerivation rec {
     substituteInPlace src/common/classes/TccPaths.ts \
       --replace "/etc/tcc" "/var/lib/tcc" \
       --replace "/opt/tuxedo-control-center/resources/dist/tuxedo-control-center/data/service/tccd" "$out/bin/tccd"
+
+    for desktopFile in src/dist-data/tuxedo-control-center{,-tray}.desktop; do
+      substituteInPlace $desktopFile \
+        --replace "/usr/bin/tuxedo-control-center" "$out/bin/tuxedo-control-center"
+    done
    '';
 
   buildPhase = ''


### PR DESCRIPTION
This PR fixes the hardcoded path of the Tuxedo Control Center in the .desktop files that ship with it.

I've been writing this on my non-Tuxedo laptop. So this is not tested yet.

Fixes #1