### PR TITLE
idea: warn if tuxedo-keyboard is too old

### DIFF
--- a/nix/tuxedo-control-center/README.md
+++ b/nix/tuxedo-control-center/README.md
@@ -2,4 +2,5 @@
 
 1. Run `update.sh` and pass the version you want to update to as a parameter. For example: `./update.sh 1.0.9`
 1. Bump the version and SHA-256 of `tuxedo-control-center` in [default.nix](./default.nix).
+1. Adjust the version check of `tuxedo-keyboard` in [module.nix](../module.nix).
 1. Build and test.

--- a/nix/tuxedo-control-center/default.nix
+++ b/nix/tuxedo-control-center/default.nix
@@ -6,10 +6,7 @@
 let
   ## Update Instructions
   #
-  # 1. Run `./update.sh` and pass the version you want to update to as
-  #    a parameter. For example: `./update.sh 1.1.1`
-  # 2. Bump the version attribute and src SHA-256 here.
-  # 3. Build and test.
+  # see ./README.md
   version = "1.2.2";
 
   # keep in sync with update.sh!


### PR DESCRIPTION
Tuxedo Control Center has a minimum version requirement on the version of the "tuxedo_io" kernel module (at runtime). Unfortunately, a version mismatch is only logged and not shown in the GUI. There the functionality gets simply disabled.

This adds a warning if the tuxedo control center module is used and the tuxedo-keyboard version for the configured kernel is too old.