### PR TITLE
Fix second ssl error

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             "nodejs-14.21.3"
             "openssl-1.1.1t"
             "openssl-1.1.1u"
+            "openssl-1.1.1v"
           ];
         };
       }).pkgs.callPackage ./nix/tuxedo-control-center {};

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -55,6 +55,7 @@ in
       "nodejs-14.21.3"
       "openssl-1.1.1t"
       "openssl-1.1.1u"
+      "openssl-1.1.1v"
     ];
 
     systemd.services.tccd = {


### PR DESCRIPTION
A new OpenSSL package has been marked as deprecated.